### PR TITLE
Adds extra flag to skip extra header addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,8 @@ They're a pain to deal with having to check for 304 and deal with the caching st
   import eFetch from 'f-etag';
   // use eFetch like the normal fetch api.
 ```
+
+You can pass an extra flag to skip the addition of the `Access-Control-Expose-Headers` header
+``` Javascript
+    eFetch(url, options, true);
+```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ response object from the previous 200 response.
 They're a pain to deal with having to check for 304 and deal with the caching strategy yourself, this is not designed to work between refreshes in the browser. This library is aimed towards browser usage. but its not setup between browser refreshes? yes this is a requirement of an existing project but by all means plugin a caching strategy somehow in a PR.
 
 #install:
-  npm i --save f-etag
+  `npm i --save f-etag`
 
 #Usage:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "f-etag",
-  "version": "1.0.0-rc2",
+  "version": "1.0.1",
   "description": "a thin wrapper around fetch api to provide a basic level in memory cache for etags ",
   "main": "lib/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import fetch from 'isomorphic-fetch'
 const data = {}
 const etags = {}
 
-export default (url = null, options = { headers: {} }, skipExtraHeader = false) => {
+module.export = (url = null, options = { headers: {} }, skipExtraHeader = false) => {
   /* eslint no-param-reassign:0 */
   url = url ? url : options.url
   if (options.method === 'GET' || !options.method) {

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import fetch from 'isomorphic-fetch'
 const data = {}
 const etags = {}
 
-export default (url = null, options = { headers: {} }) => {
+export default (url = null, options = { headers: {} }, skipExtraHeader = false) => {
   /* eslint no-param-reassign:0 */
   url = url ? url : options.url
   if (options.method === 'GET' || !options.method) {
@@ -12,7 +12,9 @@ export default (url = null, options = { headers: {} }) => {
       options.headers['If-None-Match'] = etag
     }
 
-    options.headers['Access-Control-Expose-Headers'] = 'ETag'
+    if (!skipExtraHeader) {
+      options.headers['Access-Control-Expose-Headers'] = 'ETag';
+    }
 
     return fetch(url, options)
     .then((response) => {


### PR DESCRIPTION
I have the problem that the API I'm talking to doesn't allow the `Access-Control-Expose-Headers` in the request, but it allows the `ETag` in the header.

This PR creates the option to skip the addition of the `Access-Control-Expose-Headers` if needed.
It doesn't change the current behavior
