### PR TITLE
Removed isomorphic-fetch dependency and other fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,22 @@
-#f-etag
-A thin wrapper around fetch api, we use `isomorphic-fetch` to allow this to work in a node environment.
-For a given 200 response with an Etag header we resolve the promise for the current request and clone
-response and store it in an in memory cache. For a 304 response with a matching ETag header we resolve the same
-response object from the previous 200 response.
+# f-etag
 
-## Why etag caching?
-They're a pain to deal with having to check for 304 and deal with the caching strategy yourself, this is not designed to work between refreshes in the browser. This library is aimed towards browser usage. but its not setup between browser refreshes? yes this is a requirement of an existing project but by all means plugin a caching strategy somehow in a PR.
+A thin wrapper around the `fetch` API. For a given 200 response with an ETag header we resolve the promise for the current request and clone the response and store it in an in-memory cache. For a 304 response with a matching ETag header we resolve the same response object from the previous 200 response.
 
-#install:
-  npm i --save f-etag
+## Why ETag caching?
 
-#Usage:
+They’re a pain to deal with having to check for 304 and deal with the caching strategy yourself, this is not designed to work between refreshes in the browser. This library is aimed towards browser usage. But it’s not setup between browser refreshes? Yes this is a requirement of an existing project but by all means plugin a caching strategy somehow in a PR.
 
-``` Javascript
-  import eFetch from 'f-etag';
-  // use eFetch like the normal fetch api.
+## Install
+
+```shell
+npm install f-etag isomorphic-unfetch
+```
+
+## Usage
+
+```js
+import 'isomorphic-unfetch'
+import eFetch from 'f-etag';
+
+// Use eFetch like the normal fetch API.
 ```

--- a/package.json
+++ b/package.json
@@ -34,9 +34,8 @@
     "chai": "^3.5.0",
     "eslint": "^2.7.0",
     "eslint-config-rackt": "^1.1.1",
-    "mocha": "^2.4.5"
-  },
-  "dependencies": {
-    "isomorphic-fetch": "^2.2.1"
+    "isomorphic-unfetch": "^2.0.0",
+    "mocha": "^2.4.5",
+    "nock": "^9.1.5"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
-import fetch from 'isomorphic-fetch'
 const data = {}
 const etags = {}
 

--- a/test/fetag.js
+++ b/test/fetag.js
@@ -1,3 +1,4 @@
+import 'isomorphic-unfetch'
 import { expect } from 'chai'
 import nock from 'nock'
 import fEtag from '../src'


### PR DESCRIPTION
- Removed `isomorphic-fetch` dependency.
- Added `isomorphic-unfetch` as a dev dependency for the tests.
- Added missing `nock` dev dependency that was causing errors when attempting to run tests.
- Documented `isomorphic-unfetch` installation and usage.
- Fixed readme markdown and grammar issues.

Best practice for library authors is to allow consumers to polyfill `fetch` themselves. Many people have dropped `isomorphic-fetch` for `isomorphic-unfetch`, which has a minimal impact on client bundles. It is recommended in Next.js examples.